### PR TITLE
build configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,26 @@ out/
 .dynamodb/
 .tern-port
 
+# TypeScript compilation outputs in source directories
+# Ignore compiled files but keep TypeScript sources
+**/*.js
+**/*.d.ts
+**/*.js.map
+**/*.d.ts.map
+# But allow config files
+!*.config.js
+!jest.config.js
+!jest.preset.js
+!jest.setup.js
+!*.setup.js
+!vite.config.js
+!vitest.config.js
+!tailwind.config.js
+!postcss.config.js
+!next.config.js
+!webpack.config.js
+!rollup.config.js
+
 # Testing
 coverage/
 .nyc_output/

--- a/apps/api-example/tsconfig.json
+++ b/apps/api-example/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/event-handler/tsconfig.json
+++ b/apps/event-handler/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared-utils/tsconfig.json
+++ b/packages/shared-utils/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tools/tests/contract/test_deployment_completed_event.ts
+++ b/tools/tests/contract/test_deployment_completed_event.ts
@@ -50,10 +50,7 @@ describe('deployment.completed event', () => {
         metrics: {
           deploymentTime: 180000,
           healthCheckTime: 30000,
-          dnsPropa
-
-
-gationTime: 45000,
+          dnsPropagationTime: 45000,
           rollbackTime: null
         },
         performance: {


### PR DESCRIPTION
- ✅ .gitignore - Updated to ignore compiled JS/declaration files
  - ✅ tools/tests/contract/test_deployment_completed_event.ts - Fixed syntax error
  - ✅ apps/api-example/tsconfig.json - New build config
  - ✅ apps/event-handler/tsconfig.json - New build config
  - ✅ packages/shared-utils/tsconfig.json - New build config
  - ✅ packages/test-utils/tsconfig.json - New build config

  All 32 compiled files from packages/shared-types/ are now properly ignored.